### PR TITLE
remove core-js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "core-js": "^3.6.1",
     "gsap": "^3.0.4",
     "vue": "^2.6.11"
   },


### PR DESCRIPTION
There is no difference in the `dist` files with this dependency gone so it is just unused. It does remain as a indirect devDependency:

```
vue-bar-graph@1.2.0
└─┬ @vue/cli-plugin-babel@4.5.12
  └─┬ @vue/babel-preset-app@4.5.12
    └── core-js@3.10.0
```

Fixes: https://github.com/lafriks/vue-bar-graph/issues/3

Note: `package-lock.json` remains unchanged after this change, I double-checked.