### PR TITLE
Fixing deep watch requirement on dataPoints prop

### DIFF
--- a/src/components/VueBarGraph.vue
+++ b/src/components/VueBarGraph.vue
@@ -245,8 +245,11 @@ export default {
     },
   },
   watch: {
-    dataPoints(updatedPoints) {
-      this.tween(updatedPoints);
+    dataPoints: {
+      handler(updatedPoints) {
+        this.tween(updatedPoints);
+      },
+      deep: true
     },
   },
   created() {


### PR DESCRIPTION
An issue appears to be present in how the `VueBarGraph.dataPoints` prop is watched and acted upon. It appears that the watcher used to act upon changes of the `VueBarGraph.dataPoints` prop needs to pass an option of deep: true in order to function as expected.

https://v3-migration.vuejs.org/breaking-changes/watch.html

Resolves https://github.com/lafriks/vue-bar-graph/issues/19
